### PR TITLE
Epic Search Query sometimes failing to find game fix

### DIFF
--- a/CommonPlayniteShared/PluginLibrary/EpicLibrary/Services/WebStoreClient.cs
+++ b/CommonPlayniteShared/PluginLibrary/EpicLibrary/Services/WebStoreClient.cs
@@ -29,7 +29,7 @@ namespace CommonPlayniteShared.PluginLibrary.EpicLibrary.Services
         public async Task<List<WebStoreModels.QuerySearchResponse.Data.CatalogItem.SearchStore.SearchStoreElement>> QuerySearch(string searchTerm)//public async Task<List<WebStoreModels.QuerySearchResponse.SearchStoreElement>> QuerySearch(string searchTerm)
         {
             var query = new WebStoreModels.QuerySearch();
-            query.variables.keywords = HttpUtility.UrlPathEncode(searchTerm);
+            query.variables.keywords = HttpUtility.UrlEncode(searchTerm);
             var content = new StringContent(Serialization.ToJson(query), Encoding.UTF8, "application/json");
             var response = await httpClient.PostAsync(GraphQLEndpoint, content);
             var str = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
I noticed this issue when trying to get the achievement data for "The Caligula Effect 2" on Epic Games. Using UrlPathEncode was returning "The%20Caligula%20Effect%202" which didn't return the correct game, by changing it to UrlEncode it was then using "The+Caligula+Effect+2" which returned only that game as a result. I have tried refreshing on a bunch of the games I have on EGS that have achievements and this appears to be working for it