### PR TITLE
Update ProfileUser.cs

### DIFF
--- a/CommonPluginsStores/Gog/Models/ProfileUser.cs
+++ b/CommonPluginsStores/Gog/Models/ProfileUser.cs
@@ -25,7 +25,7 @@ namespace CommonPluginsStores.Gog.Models
     public class Stats
     {
         public int games_owned { get; set; }
-        public int achievements { get; set; }
+        public int? achievements { get; set; }
         public int hours_played { get; set; }
     }
 


### PR DESCRIPTION
`achievements` integer can be null, when it is the deserializer currently fails.