### PR TITLE
Allowing Non-Director's Cut Death Stranding to be found for achievements

### DIFF
--- a/CommonPluginsStores/Epic/EpicApi.cs
+++ b/CommonPluginsStores/Epic/EpicApi.cs
@@ -429,6 +429,10 @@ namespace CommonPluginsStores.Epic
             {
                 Name = "warhammer mechanicus";
             }
+            else if (Name.IsEqual("death stranding"))
+            {
+                return "death-stranding";
+            }
 
             string ProductSlug = string.Empty;
 


### PR DESCRIPTION
Death Stranding has it's own achievements, but cannot be found in the store anymore due to it being replaced with the Director's Cut. This means that it can't be found with the QuerySearch either. So have added a small hard coding to return the ProductSlug if the game name is Death Stranding, it does mean that Director's Cut version game cannot be named just "Death Stranding" if in the Epic Library