### PR TITLE
Use SizeToContent for windows without resize

### DIFF
--- a/CommonPluginsShared/PlayniteUiHelper.cs
+++ b/CommonPluginsShared/PlayniteUiHelper.cs
@@ -86,6 +86,11 @@ namespace CommonPluginsShared
                 windowExtension.SizeToContent = SizeToContent.WidthAndHeight;
             }
 
+            if (windowExtension.ResizeMode == ResizeMode.NoResize)
+            {
+                windowExtension.SizeToContent = SizeToContent.WidthAndHeight;
+            }
+
             // Add escape event
             windowExtension.PreviewKeyDown += new KeyEventHandler(HandleEsc);
 


### PR DESCRIPTION
I don't think it's a good idea to assume window dimensions if resize is disabled.

Some themes have a bigger title bar and controls with resize disabled should use `SizeToContent` in this case to properly display everything.

The same issue happened with the `FriendlySetTime` extension: https://github.com/erys/FriendlySetTimePlaynitePlugin/pull/5
There's an image of the underlying issue which affects the `GameActivity` extension (and potentially other extensions with fixed window dimensions too).

Confirmed these changes to work for `GameActivity`.
Other extensions unconfirmed right now.

Additionally it's preferable to always use `SizeToContent` after the window got all controls with their right dimensions added. This would work for windows with resize enabled or disabled and even for windows with scroll bars (this is not included in this pull request right now - reason for the draft pull request).