### PR TITLE
Allow commas in cookie values

### DIFF
--- a/CommonPluginsShared/Tools.cs
+++ b/CommonPluginsShared/Tools.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Web;
 
 namespace CommonPluginsShared
 {
@@ -206,6 +207,21 @@ namespace CommonPluginsShared
             }
 
             return string.Empty;
+        }
+
+        public static string FixCookieValue(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+
+            if (str[0] != '"' && str.IndexOf(',') >= 0)
+            {
+                return HttpUtility.UrlEncode(str);
+            }
+
+            return str;
         }
     }
 }

--- a/CommonPluginsShared/Web.cs
+++ b/CommonPluginsShared/Web.cs
@@ -169,7 +169,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -409,7 +409,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -550,7 +550,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -712,7 +712,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -775,7 +775,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 


### PR DESCRIPTION
Fixing System.Net.CookieException - https://github.com/Lacro59/playnite-successstory-plugin/issues/412#issuecomment-1830501280

Currently, CookieContainer does [not allow](https://github.com/dotnet/runtime/issues/58773) comma-separated values, but steam uses comma-separated cookies (example "timezoneOffset=7200,0" - this value is needed for the correct time in Achievement.DateUnlocked)
