### PR TITLE
Fix DateUnlocked

### DIFF
--- a/CommonPluginsShared/Tools.cs
+++ b/CommonPluginsShared/Tools.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Web;
 
 namespace CommonPluginsShared
 {
@@ -206,6 +207,21 @@ namespace CommonPluginsShared
             }
 
             return string.Empty;
+        }
+
+        public static string FixCookieValue(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+
+            if (str[0] != '"' && str.IndexOf(',') >= 0)
+            {
+                return HttpUtility.UrlEncode(str);
+            }
+
+            return str;
         }
     }
 }

--- a/CommonPluginsShared/Web.cs
+++ b/CommonPluginsShared/Web.cs
@@ -169,7 +169,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -409,7 +409,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -561,7 +561,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -723,7 +723,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 
@@ -786,7 +786,7 @@ namespace CommonPluginsShared
                 {
                     Cookie c = new Cookie();
                     c.Name = cookie.Name;
-                    c.Value = cookie.Value;
+                    c.Value = Tools.FixCookieValue(cookie.Value);
                     c.Domain = cookie.Domain;
                     c.Path = cookie.Path;
 

--- a/CommonPluginsShared/Web.cs
+++ b/CommonPluginsShared/Web.cs
@@ -466,7 +466,18 @@ namespace CommonPluginsShared
                             var urlParams = url.Split('?').ToList();
                             if (urlParams.Count == 2)
                             {
-                                urlNew += "?" + urlParams[1];
+                                var urlNewParams = urlNew.Split('?').ToList();
+                                if (urlNewParams.Count == 2)
+                                {
+                                    if (urlParams[1] != urlNewParams[1])
+                                    {
+                                        urlNew += "&" + urlParams[1];
+                                    }
+                                }
+                                else
+                                {
+                                    urlNew += "?" + urlParams[1];
+                                }
                             }
                         }
 

--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -507,11 +507,11 @@ namespace CommonPluginsStores.Steam
                         if (!stringDateUnlocked.IsNullOrEmpty())
                         {
                             stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Replace("<br>", string.Empty).Trim() + " -8";
-                            DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                            DateTime.TryParseExact(stringDateUnlocked, "d MMM, yyyy @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
 
                             if (DateUnlocked == default)
                             {
-                                DateTime.TryParseExact(stringDateUnlocked, "dd MMM @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                                DateTime.TryParseExact(stringDateUnlocked, "d MMM @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
                             }
 
                             DateUnlocked = DateUnlocked.ToLocalTime();

--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -506,20 +506,13 @@ namespace CommonPluginsStores.Steam
                         string stringDateUnlocked = el.QuerySelector(".achieveUnlockTime")?.InnerHtml ?? string.Empty;
                         if (!stringDateUnlocked.IsNullOrEmpty())
                         {
-                            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Replace("<br>", string.Empty).Trim() + " -8";
-                            DateTime.TryParseExact(stringDateUnlocked, "d MMM, yyyy @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
-
-                            if (DateUnlocked == default)
-                            {
-                                DateTime.TryParseExact(stringDateUnlocked, "d MMM @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
-                            }
-
-                            DateUnlocked = DateUnlocked.ToLocalTime();
+                            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Replace("<br>", string.Empty).Trim();
+                            DateTime.TryParseExact(stringDateUnlocked, new [] { "d MMM, yyyy @ h:mmtt", "d MMM @ h:mmtt" }, new CultureInfo("en-US"), DateTimeStyles.AssumeLocal, out DateUnlocked);
                         }
 
                         if (DateUnlocked != default)
                         {
-                            gameAchievement.Where(x => x.UrlUnlocked.Split('/').Last().IsEqual(UrlUnlocked.Split('/').Last())).FirstOrDefault().DateUnlocked = DateUnlocked.ToUniversalTime();
+                            gameAchievement.Where(x => x.UrlUnlocked.Split('/').Last().IsEqual(UrlUnlocked.Split('/').Last())).FirstOrDefault().DateUnlocked = DateUnlocked;
                         }
                     }
                 }


### PR DESCRIPTION
Fix duplicate parameters in the url when redirecting and  fix parsing DateUnlocked value.

Before (the english parameter was ignored):
![Знімок екрана 2024-01-07 200412](https://github.com/Lacro59/playnite-plugincommon/assets/2897430/382be656-6682-42c0-ad47-01744c772f89)
![image](https://github.com/Lacro59/playnite-plugincommon/assets/2897430/d78fd309-40b8-4a63-a875-76badc06af5d)

After:
![image](https://github.com/Lacro59/playnite-plugincommon/assets/2897430/b9cfa66c-57c2-44b6-8443-ed8ace258fe1)

#103 Lacro59/playnite-successstory-plugin#412
