### PR TITLE
fix steam achievements with non-unique UrlUnlocked

### DIFF
--- a/CommonPluginsResources/Localization/Common/fr_FR.xaml
+++ b/CommonPluginsResources/Localization/Common/fr_FR.xaml
@@ -36,7 +36,7 @@
     <sys:String x:Key="LOCCommonLoggedIn">Utilisateur connecté</sys:String>
     <sys:String x:Key="LOCCommonAccountName">Nom du compte</sys:String>
     <sys:String x:Key="LOCCommonLoginChecking">Vérification du statut d'authentification…</sys:String>
-    <sys:String x:Key="LOCCommonPrivateChecking">Checking private status…</sys:String>
+    <sys:String x:Key="LOCCommonPrivateChecking">Vérification du statut privé…</sys:String>
 
     <sys:String x:Key="LOCCommonStoresNoAuthenticate">{0}: utilisateur non authentifié</sys:String>
     <sys:String x:Key="LOCCommonStoreNoApiKey">{0}: Aucune clé API</sys:String>

--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -502,7 +502,21 @@ namespace CommonPluginsStores.Steam
 
                         if (DateUnlocked != default)
                         {
-                            gameAchievement.Where(x => x.UrlUnlocked.Split('/').Last().IsEqual(UrlUnlocked.Split('/').Last())).FirstOrDefault().DateUnlocked = DateUnlocked;
+
+                            List<GameAchievement> achievements = gameAchievement.Where(x => x.UrlUnlocked.Split('/').Last().IsEqual(UrlUnlocked.Split('/').Last())).ToList();
+
+                            if (achievements.Count == 1)
+                            {
+                                achievements[0].DateUnlocked = DateUnlocked;
+                            }
+                            else
+                            {
+                                var achievement = achievements.FirstOrDefault(x => x.Name.IsEqual(Name));
+                                if (achievement != null)
+                                {
+                                    achievement.DateUnlocked = DateUnlocked;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Some games do not have unique achievement pictures (Example: [One More Line](https://steamcommunity.com/stats/356890/achievements) )

Before: 
![image](https://github.com/Lacro59/playnite-plugincommon/assets/2897430/46ba6d42-1074-43f3-b9f7-75e433da8204)

After:
![image](https://github.com/Lacro59/playnite-plugincommon/assets/2897430/bc8a0f3f-221e-45f9-9b0a-0174e46ba750)
