### PR TITLE
[Epic Games] - Using gameName to match the link URL if it exists

### DIFF
--- a/CommonPluginsStores/Epic/EpicApi.cs
+++ b/CommonPluginsStores/Epic/EpicApi.cs
@@ -632,15 +632,20 @@ namespace CommonPluginsStores.Epic
             return ProductSlug;
         }
 
-        public string GetProductSlugByUrl(string url)
+        public string GetProductSlugByUrl(string url, string gameName)
         {
             string ProductSlug = string.Empty;
 
             try
             {
-                if (url.Contains(".epicgames.com/", StringComparison.InvariantCultureIgnoreCase))
+                string[] urlSplit = url.Split('/');
+
+                foreach (string slug in urlSplit)
                 {
-                    ProductSlug = url.Replace("/home", string.Empty).Split('/').Last();
+                    if (slug.ContainsInvariantCulture(gameName.ToLower(), System.Globalization.CompareOptions.IgnoreSymbols))
+                    {
+                        ProductSlug = slug;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
When looping through the links saved to a game if it checks Epic I've altered how it checks for the productSlug as previously it was having issues in some specific cases, example being "Homeworld Remastered", the url would be epicgames.com/p/homeworld-remastered, because it has "/home" it would remove that and would leave you with "pworld-remastered", this changed gets past that