### PR TITLE
Update getNameSpace method in EpicApi.cs

### DIFF
--- a/CommonPluginsStores/Epic/EpicApi.cs
+++ b/CommonPluginsStores/Epic/EpicApi.cs
@@ -792,7 +792,7 @@ namespace CommonPluginsStores.Epic
         public string GetNameSpace(Game game)
         {
             string productSlug = GetProducSlug(game);
-            string normalizedEpicName = PlayniteTools.NormalizeGameName(game.Name.Replace("'", ""));
+            string normalizedEpicName = PlayniteTools.NormalizeGameName(game.Name.Replace("'", "").Replace(",", ""));
 
             // The search don't find the classic game
             if (productSlug == "death-stranding")


### PR DESCRIPTION
Missed a check for a comma when getting nameSpace, results in no achievements being found for Warhammer 40,000: Space Marine 2, as it would still normalise the title as "warhammer 40 000 space marine 2", instead of "warhammer 40000 space marine 2"