### PR TITLE
Changing UrlSteamGame to use store instead of api url

### DIFF
--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -57,7 +57,7 @@ namespace CommonPluginsStores.Steam
         private static string UrlWishlistRemove => UrlStore + @"/api/removefromwishlist";
 
         private static string UrlApiGameDetails => UrlStore + @"/api/appdetails?appids={0}&l={1}";
-        private static string UrlSteamGame => UrlApi + @"/app/{0}/?l={1}";
+        private static string UrlSteamGame => UrlStore + @"/app/{0}/?l={1}";
         #endregion
 
         protected List<SteamApp> steamApps;


### PR DESCRIPTION
This should fix https://github.com/Lacro59/playnite-checkdlc-plugin/issues/80, but I did not check the other plugins that use this plugin library.