### PR TITLE
Detect missing dates on unlocked Steam achievements

### DIFF
--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -1113,12 +1113,18 @@ namespace CommonPluginsStores.Steam
 
                             if (lang.Equals("english"))
                             {
+                                bool isUnlocked = (el.GetAttribute("data-panel") ?? string.Empty).Contains("autoFocus");
                                 string stringDateUnlocked = el.QuerySelector(".achieveUnlockTime")?.InnerHtml ?? string.Empty;
 
                                 if (!stringDateUnlocked.IsNullOrEmpty())
                                 {
                                     stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Replace("<br>", string.Empty).Trim();
                                     _ = DateTime.TryParseExact(stringDateUnlocked, new[] { "d MMM, yyyy @ h:mmtt", "d MMM @ h:mmtt" }, new CultureInfo("en-US"), DateTimeStyles.AssumeLocal, out DateUnlocked);
+                                }
+                                else if (isUnlocked)
+                                {
+                                    DateUnlocked = i > 0 ? unlockedDates[i - 1] : DateTime.Today;
+                                    Logger.Warn($"No valid date found for unlocked achievement \"{Name}\"");
                                 }
 
                                 if (unlockedDates == null)


### PR DESCRIPTION
In some rare cases, unlocked Steam achievements might not have an unlock date. This change detects those achievements and adds a date.

Currently, when parsing the web page's HTML, this plugin searches for achievement rows with the tag `<div class="achieveUnlockTime">`. When this tag is not found, the achievement is marked as locked, even when it is actually unlocked. To prevent this issue, I added another check. In the parsed HTML, achievement rows only have `autoFocus` in the `data-panel` attribute when the achievement is unlocked. By adding a check for this string, I can detect achievements that are unlocked but do not have an unlock date.

To mark those achievements as unlocked, I have to set the unlock date. I use the date of the previous unlocked achievement and if there is no previous unlocked achievement, I use today's date. This way, in the rare cases where unlocked achievements have no unlock date (e.g. connection lost while playing), all unlocked achievements are correctly marked as unlocked.

[missing_dates_example.json](https://github.com/user-attachments/files/17368417/missing_dates_example.json): There are 2 entries where `achieved`=1 and `unlocktime`=0