### PR TITLE
Fixing GOG achievements for public profiles

### DIFF
--- a/CommonPluginsShared/Tools.cs
+++ b/CommonPluginsShared/Tools.cs
@@ -211,11 +211,11 @@ namespace CommonPluginsShared
 
         public static string GetJsonInString(string source, string regexBefore)
         {
-            string pattern = regexBefore + @"({.*})[;]?[<]?";
+            string pattern = regexBefore + @"[{\W\D\S}]+?(?=\;)";
             Match match = Regex.Match(source, pattern);
             if (match.Success)
             {
-                return match.Groups[1].Value;
+                return match.Groups[0].Value;
             }
             else
             {

--- a/CommonPluginsStores/Gog/GogApi.cs
+++ b/CommonPluginsStores/Gog/GogApi.cs
@@ -397,7 +397,7 @@ namespace CommonPluginsStores.Gog
                 string url = string.Format(UrlUserGameAchievements, accountInfos.Pseudo, id, accountInfos.UserId);
                 string urlLang = string.Format(UrlGogLang, CodeLang.GetGogLang(Local).ToLower());
                 string response = Web.DownloadStringDataWithUrlBefore(url, urlLang).GetAwaiter().GetResult();
-                string jsonDataString = Tools.GetJsonInString(response, "window.profilesData.achievements[ ]?=[ ]?");
+                string jsonDataString = Tools.GetJsonInString(response, "(?<=window.profilesData.achievements\\s=\\s)");
 
                 ObservableCollection<GameAchievement> gameAchievements = new ObservableCollection<GameAchievement>();
                 if (Serialization.TryFromJson(jsonDataString, out dynamic data))


### PR DESCRIPTION
Currently SuccessStory cannot get GOG achievements at all, this fixes it if your profile is public. When debugging the regex that was being used wasn't returning any values. I have changed the regex and now it returns correctly.

Here is a regexr script that shows it matches properly on the achievements regexr.com/89bbj.

I have attached a picture of my IDE getting the response correctly as well, the contents of jsonDataString contains the achievement data

![image](https://github.com/user-attachments/assets/ecb0541a-8c28-4146-abaf-2a3e60dbce7b)
