### PR TITLE
[Steam] Fixing Crash caused by GOG achievement fix

### DIFF
--- a/CommonPluginsShared/Tools.cs
+++ b/CommonPluginsShared/Tools.cs
@@ -211,7 +211,7 @@ namespace CommonPluginsShared
 
         public static string GetJsonInString(string source, string regexForward)
         {
-            string pattern = regexForward + @"(\[?{.*}\]?)[;]?[<]?";
+            string pattern = regexForward + @"(\[?{.*}\]?)[<]?";
             Match match = Regex.Match(source, pattern);
             if (match.Success)
             {

--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -179,7 +179,7 @@ namespace CommonPluginsStores.Steam
                         if (idMatch.Success)
                         {
                             _ = SetStoredCookies(GetWebCookies());
-                            string JsonDataString = Tools.GetJsonInString(source, @"g_rgProfileData[ ]?=[ ]?");
+                            string JsonDataString = Tools.GetJsonInString(source, @"(?<=g_rgProfileData[ ]=[ ])");
                             RgProfileData rgProfileData = Serialization.FromJson<RgProfileData>(JsonDataString);
 
                             CurrentAccountInfos = new AccountInfos


### PR DESCRIPTION
Under https://github.com/Lacro59/playnite-plugincommon/pull/135 had made changes to the Regex, this regex is being called when Steam authentication happens to grab the account information. I have fixed the regex for this and the authentication is now not crashing and can get achievements without issue. Tweaked the Regex to not include semi-colons as this was resulting in malformed JSON when it was trying read it.

Only matches on the JSON
![image](https://github.com/user-attachments/assets/0b6b2abe-5d4b-4c0a-92e2-8334d4e5e875)
