### PR TITLE
Get Steam AppId from links if available

### DIFF
--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -690,12 +690,15 @@ namespace CommonPluginsStores.Steam
 
         #region Steam
         /// <summary>
-        /// Get AppId from Steam store with a game name.
+        /// Get AppId from Steam store with a game.
         /// </summary>
-        /// <param name="Name"></param>
+        /// <param name="game"></param>
         /// <returns></returns>
-        public uint GetAppId(string Name)
+        public uint GetAppId(Game game)
         {
+            var appIdFromLinks = GetAppIdFromLinks(game);
+            if (appIdFromLinks != 0) return appIdFromLinks;
+
             if (SteamApps == null)
             {
                 Logger.Warn("SteamApps is empty");
@@ -703,21 +706,36 @@ namespace CommonPluginsStores.Steam
             }
 
             SteamApps.Sort((x, y) => x.AppId.CompareTo(y.AppId));
-            List<uint> found = SteamApps.FindAll(x => x.Name.IsEqual(Name, true)).Select(x => x.AppId).Distinct().ToList();
+            List<uint> found = SteamApps.FindAll(x => x.Name.IsEqual(game.Name, true)).Select(x => x.AppId).Distinct().ToList();
 
             if (found != null && found.Count > 0)
             {
                 if (found.Count > 1)
                 {
-                    Logger.Warn($"Found {found.Count} SteamAppId data for {Name}: " + string.Join(", ", found));
+                    Logger.Warn($"Found {found.Count} SteamAppId data for {game.Name}: " + string.Join(", ", found));
                     return 0;
                 }
 
-                Common.LogDebug(true, $"Found SteamAppId data for {Name} - {Serialization.ToJson(found)}");
+                Common.LogDebug(true, $"Found SteamAppId data for {game.Name} - {Serialization.ToJson(found)}");
                 return found.First();
             }
 
             return 0;
+        }
+
+        private uint GetAppIdFromLinks(Game game)
+        {
+            var steamLink = game.Links?.FirstOrDefault(link => link.Name.ToLower() == "steam");
+            if (steamLink == null) return 0;
+
+            var linkSplit = steamLink.Url.Split(new[] { "/app/" }, StringSplitOptions.None);
+            var steamIdString = linkSplit?.ElementAtOrDefault(1)?.Split('/').FirstOrDefault();
+            if (steamIdString == null) return 0;
+
+            var success = UInt32.TryParse(steamIdString, out var steamId);
+            if (!success) return 0;
+
+            return steamId;
         }
 
         /// <summary>


### PR DESCRIPTION
If metadata is filled with IGDB or just synced from Steam then the links fields will be available so we can get AppId from there more reliably.