### PR TITLE
Fix date parser to support US date formats.

### DIFF
--- a/CommonPluginsStores/Steam/SteamApi.cs
+++ b/CommonPluginsStores/Steam/SteamApi.cs
@@ -1121,7 +1121,7 @@ namespace CommonPluginsStores.Steam
                                 if (!stringDateUnlocked.IsNullOrEmpty())
                                 {
                                     stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Replace("<br>", string.Empty).Trim();
-                                    _ = DateTime.TryParseExact(stringDateUnlocked, new[] { "d MMM, yyyy @ h:mmtt", "d MMM @ h:mmtt" }, new CultureInfo("en-US"), DateTimeStyles.AssumeLocal, out DateUnlocked);
+                                    _ = DateTime.TryParseExact(stringDateUnlocked, new[] { "d MMM, yyyy @ h:mmtt", "d MMM @ h:mmtt", "MMM d, yyyy @ h:mmtt", "MMM d @ h:mmtt" }, new CultureInfo("en-US"), DateTimeStyles.AssumeLocal, out DateUnlocked);
                                 }
                                 else if (isUnlocked)
                                 {


### PR DESCRIPTION
The date formatter did not support US date formats (Month Day, Year) and so if a user had their profile configured to show dates in that format, the parsing would fail, and no achievements would load.

This fixes that so that a US-style date format is also accepted by the parser.